### PR TITLE
Remove missing migrations from torchbox/wagtail.

### DIFF
--- a/kagiso_image/migrations/0002_auto_20160322_1251.py
+++ b/kagiso_image/migrations/0002_auto_20160322_1251.py
@@ -12,7 +12,7 @@ from django.conf import settings
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailcore', '0029_auto_20160322_1251'),
+        ('wagtailcore', '0028_merge'),
         ('kagiso_image', '0001_initial'),
     ]
 


### PR DESCRIPTION
For dependencies reason this '0029_auto_20160322_1251' migrations does not exist in torchbox/wagtail. Therefore, I changed it to '0028_merge'. '0028_merge' It was the last migrations were done by torchbox/wagtail team in 'wagtail-1.4.1', not '0029_auto_20160322_1251'.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagiso-future-media/kagiso_image/2)

<!-- Reviewable:end -->
